### PR TITLE
Apply tags to AWS EBS volumes on creation.

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/aws.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/cloudprovider/providers/aws/aws.go
@@ -135,6 +135,7 @@ type AWSMetadata interface {
 
 type VolumeOptions struct {
 	CapacityMB int
+	Tags       *map[string]string
 }
 
 // Volumes is an interface for managing cloud-provisioned volumes
@@ -1201,15 +1202,15 @@ func (aws *AWSCloud) DetachDisk(instanceName string, diskName string) error {
 }
 
 // Implements Volumes.CreateVolume
-func (aws *AWSCloud) CreateVolume(volumeOptions *VolumeOptions) (string, error) {
+func (s *AWSCloud) CreateVolume(volumeOptions *VolumeOptions) (string, error) {
 	// TODO: Should we tag this with the cluster id (so it gets deleted when the cluster does?)
 	// This is only used for testing right now
 
 	request := &ec2.CreateVolumeInput{}
-	request.AvailabilityZone = &aws.availabilityZone
+	request.AvailabilityZone = &s.availabilityZone
 	volSize := (int64(volumeOptions.CapacityMB) + 1023) / 1024
 	request.Size = &volSize
-	response, err := aws.ec2.CreateVolume(request)
+	response, err := s.ec2.CreateVolume(request)
 	if err != nil {
 		return "", err
 	}
@@ -1219,6 +1220,28 @@ func (aws *AWSCloud) CreateVolume(volumeOptions *VolumeOptions) (string, error) 
 
 	volumeName := "aws://" + az + "/" + awsID
 
+	// apply tags
+	if volumeOptions.Tags != nil {
+		tags := []*ec2.Tag{}
+		for k, v := range *volumeOptions.Tags {
+			tag := &ec2.Tag{}
+			tag.Key = aws.String(k)
+			tag.Value = aws.String(v)
+			tags = append(tags, tag)
+		}
+		tagRequest := &ec2.CreateTagsInput{}
+		tagRequest.Resources = []*string{&awsID}
+		tagRequest.Tags = tags
+		if _, err := s.createTags(tagRequest); err != nil {
+			// delete the volume and hope it succeeds
+			delerr := s.DeleteVolume(volumeName)
+			if delerr != nil {
+				// delete did not succeed, we have a stray volume!
+				return "", fmt.Errorf("error tagging volume %s, could not delete the volume: %v", volumeName, delerr)
+			}
+			return "", fmt.Errorf("error tagging volume %s: %v", volumeName, err)
+		}
+	}
 	return volumeName, nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/persistentvolume_controller.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/persistentvolume_controller.go
@@ -699,6 +699,10 @@ func newCreater(plugin volume.ProvisionableVolumePlugin, claim *api.PersistentVo
 		Capacity:                      claim.Spec.Resources.Requests[api.ResourceName(api.ResourceStorage)],
 		AccessModes:                   claim.Spec.AccessModes,
 		PersistentVolumeReclaimPolicy: api.PersistentVolumeReclaimDelete,
+		CloudTags: &map[string]string{
+			cloudVolumeCreatedForNamespaceTag: claim.Namespace,
+			cloudVolumeCreatedForNameTag:      claim.Name,
+		},
 	}
 
 	provisioner, err := plugin.NewCreater(volumeOptions)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/types.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/controller/persistentvolume/types.go
@@ -38,6 +38,13 @@ const (
 	// The value must be the namespace and name of the claim being bound to (i.e, claim.Namespace/claim.Name)
 	// This is an experimental feature and likely to change in the future.
 	provisionedForKey = "volume.experimental.kubernetes.io/provisioned-for"
+
+	// Name of a tag attached to a real volume in cloud (e.g. AWS EBS or GCE PD)
+	// with namespace of a persistent volume claim used to create this volume.
+	cloudVolumeCreatedForNamespaceTag = "kubernetes.io/created-for/PVC/Namespace"
+	// Name of a tag attached to a real volume in cloud (e.g. AWS EBS or GCE PD)
+	// with name of a persistent volume claim used to create this volume.
+	cloudVolumeCreatedForNameTag = "kubernetes.io/created-for/PVC/Name"
 )
 
 // persistentVolumeOrderedIndex is a cache.Store that keeps persistent volumes indexed by AccessModes and ordered by storage capacity.

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_ebs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_ebs.go
@@ -407,7 +407,8 @@ func (d *awsElasticBlockStoreDeleter) Delete() error {
 
 type awsElasticBlockStoreCreater struct {
 	*awsElasticBlockStore
-	options volume.VolumeOptions
+	options   volume.VolumeOptions
+	namespace string
 }
 
 var _ volume.Creater = &awsElasticBlockStoreCreater{}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_util.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/aws_ebs/aws_util.go
@@ -136,7 +136,9 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreCreater) (string, i
 	volSize := int((c.options.Capacity.Value() + mega - 1) / mega)
 	volSpec := &aws_cloud.VolumeOptions{
 		CapacityMB: volSize,
+		Tags:       c.options.CloudTags,
 	}
+
 	name, err := cloud.(*aws_cloud.AWSCloud).CreateVolume(volSpec)
 	if err != nil {
 		glog.V(2).Infof("Error creating AWS EBS volume: %v", err)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/plugins.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/volume/plugins.go
@@ -50,6 +50,8 @@ type VolumeOptions struct {
 	PersistentVolumeReclaimPolicy api.PersistentVolumeReclaimPolicy
 	// Quality of Service tier requested by the user
 	QOSTier string
+	// Tags to attach to the real volume in the cloud provider - e.g. AWS EBS
+	CloudTags *map[string]string
 }
 
 // VolumePlugin is an interface to volume plugins that can be used on a


### PR DESCRIPTION
When Kubernetes creates a volume, it adds some tags to it so the admin
knows where this volume comes from:

kubernetes.io/created-for/PVC/Namespace - namespace of appropriate PVC
kubernetes.io/created-for/PVC/Name - name of the PVC
